### PR TITLE
[배포] 배포용 API 서버 주소 변경

### DIFF
--- a/packages/client/src/common/constants.ts
+++ b/packages/client/src/common/constants.ts
@@ -10,10 +10,10 @@ const sizeMap = {
 
 export default sizeMap
 
-const SOCKET_URL = process.env.NODE_ENV === 'development' ? 'localhost:3050' : 'http://34.64.167.225:3050'
+const SOCKET_URL = process.env.NODE_ENV === 'development' ? 'localhost:3050' : 'https://kakio.site/v1'
 
 const API_SERVER_URL = 'http://localhost:3050/v1/'
-const API_SERVER_URL_PRODUCT = 'http://34.64.167.225:3050/v1/'
+const API_SERVER_URL_PRODUCT = 'https://kakio.site/v1/'
 
 const NODE_ENV_VAR = process.env.NODE_ENV
 const CLIENT_ID = process.env.REACT_APP_GOOGLE_CLIENT_ID || ''


### PR DESCRIPTION
https://kakio.site/v1 로 변경

closes #131 