### PR TITLE
[리팩토링] api request 관련 타입 수정

### DIFF
--- a/packages/client/src/common/request.ts
+++ b/packages/client/src/common/request.ts
@@ -31,7 +31,7 @@ async function Axios<T>(config: AxiosRequestConfig) {
     const response = await instance.request<ResponseType<T>>(config)
     return response.data.data
   } catch (e) {
-    throw new Error(e)
+    throw new Error(e.response.data.data.message)
   }
 }
 

--- a/packages/client/src/common/request.ts
+++ b/packages/client/src/common/request.ts
@@ -1,10 +1,8 @@
 import axios, {
-  AxiosRequestConfig, AxiosResponse,
+  AxiosError, AxiosRequestConfig, AxiosResponse,
 } from 'axios'
 import * as Type from 'types'
-import {
-  APIs, Models,
-} from '@kakio/common'
+import { APIs, Models } from '@kakio/common'
 import { configs } from './constants'
 
 const API_SERVER_URL = configs.NODE_ENV_VAR === 'production' ? configs.API_SERVER_URL_PRODUCT : configs.API_SERVER_URL
@@ -29,38 +27,31 @@ export type ApiCallback<T = {}> = (
 ) => void
 
 async function Axios<T>(config: AxiosRequestConfig) {
-  return instance.request<ResponseType<T>>(config)
+  try {
+    const response = await instance.request<ResponseType<T>>(config)
+    return response.data.data
+  } catch (e) {
+    throw new Error(e)
+  }
 }
 
-export const getProfile = () => Axios({
-  method: 'GET',
-  url: 'user/my-profile',
-})
-export const getFriendList = () => Axios({
-  method: 'GET',
-  url: 'social/friend-list',
-})
-export const getChatList = () => Axios({
+export const getProfile = () => Axios<Type.ApiUser>({ method: 'GET',
+  url: 'user/my-profile' })
 
-  method: 'GET',
-  url: 'dummy/chat-list',
-})
-export const getLogout = () => Axios({
-  method: 'GET',
-  url: 'auth/logout',
-})
-export const getUserInfo = () => Axios<Type.SimpleUserType>({
-  method: 'GET',
-  url: 'auth/check-auth',
-})
+export const getFriendList = () => Axios<Type.ApiUser[]>({ method: 'GET',
+  url: 'social/friend-list' })
+export const getChatList = () => Axios({ method: 'GET',
+  url: 'dummy/chat-list' })
+export const getLogout = () => Axios({ method: 'GET',
+  url: 'auth/logout' })
+export const getUserInfo = () => Axios<Type.SimpleUserType>({ method: 'GET',
+  url: 'auth/check-auth' })
 
 interface GetFirstChat extends AxiosRequestConfig{
   roomUuid: string
 }
-export const getFirstChat = ({ roomUuid }: GetFirstChat) => Axios<APIs.GetFirstChat>({
-  method: 'GET',
-  url: `chat/first-chat/${roomUuid}`,
-})
+export const getFirstChat = ({ roomUuid }: GetFirstChat) => Axios<APIs.GetFirstChat>({ method: 'GET',
+  url: `chat/first-chat/${roomUuid}` })
 
 interface GetLoginArgs {
   googleId: string
@@ -75,34 +66,28 @@ export const getLogin = (args: GetLoginArgs) => Axios({
   data: args,
 })
 
-export const getRooms = () => Axios<Pick<Models.Room, 'uuid' | 'participants'>[]>({
-  method: 'GET',
-  url: 'chat/room',
-})
+export const getRooms = () => Axios<Models.Room[]>({ method: 'GET',
+  url: 'chat/room' })
 
-export const addFriend = (email: string) => Axios({
+export const addFriend = (email: string) => Axios<Type.ApiUser>({
   method: 'POST',
   url: 'social/add-friend',
   data: { email },
 })
 
-export const deleteFriend = (uuid: string) => Axios({
+export const deleteFriend = (uuid: string) => Axios<{uuid: string}>({
   method: 'DELETE',
   url: 'social/delete-friend',
   data: { uuid },
 })
-export const updateProfile = ({
-  name,
-  statusMessage,
-}: {
+export const updateProfile = ({ name,
+  statusMessage }: {
   name: string
   statusMessage: string
-}) => Axios({
+}) => Axios<Type.ApiUser>({
   method: 'PATCH',
   url: 'user/update-profile',
-  data: {
-    name, statusMessage,
-  },
+  data: { name, statusMessage },
 })
 
 interface GetChatByRoom {
@@ -111,7 +96,7 @@ interface GetChatByRoom {
   offset: number
 }
 
-interface Temp {
+interface Chat {
   chats: Type.ApiChat[]
   offset: number
   limit: number
@@ -121,10 +106,8 @@ export const getChatByRoom = ({
   roomUuid,
   limit,
   offset,
-}: GetChatByRoom) => Axios<Temp>({
-  method: 'GET',
-  url: `/chat/message/${roomUuid}?offset=${offset}&limit=${limit}`,
-})
+}: GetChatByRoom) => Axios<Chat>({ method: 'GET',
+  url: `/chat/message/${roomUuid}?offset=${offset}&limit=${limit}` })
 
 export const loadMoreChat = ({
   roomUuid,
@@ -138,10 +121,8 @@ export const loadMoreChat = ({
   chats: Type.ApiChat[]
   offset: number
   limit: number}
->({
-  method: 'GET',
-  url: `/chat/message/${roomUuid}?offset=${offset}&limit=${limit}`,
-})
+>({ method: 'GET',
+  url: `/chat/message/${roomUuid}?offset=${offset}&limit=${limit}` })
 
 export const makeRoomRequest = (args: Type.InviteUser[]) => Axios<Pick<Models.Room, 'uuid'>>({
   method: 'POST',

--- a/packages/client/src/modules/login/action.ts
+++ b/packages/client/src/modules/login/action.ts
@@ -1,5 +1,3 @@
-import { AxiosError } from 'axios'
-
 export const LOGIN_REQUEST = 'login/LOGIN_REQUEST' as const
 export const LOGIN_SUCCESS = 'login/LOGIN_SUCCESS' as const
 export const LOGIN_FAILURE = 'login/LOGIN_FAILURE' as const
@@ -17,7 +15,7 @@ export const loginRequest = (loginUser: LoginUserType) => ({
   type: LOGIN_REQUEST, payload: loginUser,
 })
 export const loginSuccess = () => ({ type: LOGIN_SUCCESS })
-export const loginFailure = (e: AxiosError) => ({
+export const loginFailure = (e: string) => ({
   type: LOGIN_FAILURE,
   payload: e,
 })

--- a/packages/client/src/modules/login/reducer.ts
+++ b/packages/client/src/modules/login/reducer.ts
@@ -12,9 +12,9 @@ function login(state: LoginInfo = initialState, action: LoginAction) {
     }
     case Action.LOGIN_FAILURE: {
       const error = action.payload
-      if (error.response) {
-        console.error(error.response)
-        alert.error(error.response.data.data.message)
+      if (error) {
+        console.error(error)
+        alert.error(error)
       }
       return state
     }

--- a/packages/client/src/modules/profile/action.ts
+++ b/packages/client/src/modules/profile/action.ts
@@ -1,4 +1,5 @@
 import { Models } from '@kakio/common'
+import { ApiUser } from 'types'
 
 export const GET_PROFILE_REQUEST = 'profile/GET_PROFILE' as const
 export const GET_PROFILE_SUCCESS = 'profile/GET_PROFILE_SUCCESS' as const
@@ -6,7 +7,7 @@ export const UPDATE_PROFILE_REQUEST = 'profile/UPDATE_PROFILE' as const
 export const UPDATE_PROFILE_SUCCESS = 'profile/UPDATE_PROFILE_SUCCESS' as const
 export const RESET_PROFILE = 'profile/RESET_PROFILE' as const
 export const getProfile = () => ({ type: GET_PROFILE_REQUEST })
-export const getProfileSuccess = (profile: Models.User) => ({
+export const getProfileSuccess = (profile: ApiUser) => ({
   type: GET_PROFILE_SUCCESS,
   payload: profile,
 })
@@ -18,7 +19,8 @@ export const updateProfileRequest = (profile: {
   type: UPDATE_PROFILE_REQUEST,
   payload: profile,
 })
-export const updateProfielSuccess = (profile: Models.User) => ({
+
+export const updateProfielSuccess = (profile: ApiUser) => ({
   type: UPDATE_PROFILE_SUCCESS,
   payload: profile,
 })

--- a/packages/client/src/modules/sagas/chatSaga.ts
+++ b/packages/client/src/modules/sagas/chatSaga.ts
@@ -13,32 +13,19 @@ import {
   loadMoreSuccess,
 } from 'modules/chat'
 
-import { ApiChat } from 'types'
-import { AxiosResponse } from 'axios'
+import { unwrapPromise } from 'types'
 import * as request from 'common/request'
 import {
   RootState, Store,
 } from 'modules'
 
-interface Temp {
-  chats: ApiChat[]
-  offset: number
-  limit: number
-}
-type ResponseType = AxiosResponse<request.ResponseType<Temp>>
 function* getChatSaga(action: ReturnType<typeof getChatRequest>) {
   try {
     const { roomUuid } = action.payload
-    const response: ResponseType = yield call(request.getChatByRoom, action.payload)
-    const {
-      chats, offset, limit,
-    } = response.data.data
-
+    const data: unwrapPromise<typeof request.getChatByRoom> = yield call(request.getChatByRoom, action.payload)
     yield put(getChatSuccess({
       roomUuid,
-      chats,
-      offset,
-      limit,
+      ...data,
     }))
   } catch (e) {
     yield put(getChatFailure(e))
@@ -53,14 +40,14 @@ function* loadMoreSaga(action: ReturnType<typeof loadMoreRequest>) {
     const {
       offset, limit,
     } = chatState.data[roomUuid]
-    const response: ResponseType = yield call(request.loadMoreChat, {
+    const data: unwrapPromise<typeof request.loadMoreChat> = yield call(request.loadMoreChat, {
       roomUuid,
       offset,
       limit,
     })
 
     yield put(loadMoreSuccess({
-      ...response.data.data,
+      ...data,
       roomUuid,
     }))
   } catch (e) {

--- a/packages/client/src/modules/sagas/friendsSaga.ts
+++ b/packages/client/src/modules/sagas/friendsSaga.ts
@@ -12,7 +12,7 @@ function* getFriendsSaga() {
     const data: unwrapPromise<typeof request.getFriendList> = yield call(request.getFriendList)
     yield put(Action.getFriendsSuccess(data))
   } catch (e) {
-    alert.error(e.response.data.data.message)
+    alert.error(e.message)
   }
 }
 function* addFriendSaga({ payload }: ReturnType<typeof Action.addFriend>) {
@@ -21,7 +21,7 @@ function* addFriendSaga({ payload }: ReturnType<typeof Action.addFriend>) {
     yield put(Action.addFriendSuccess(data))
     alert.addFriend(data.name)
   } catch (e) {
-    alert.error(e.response.data.data.message)
+    alert.error(e.message)
   }
 }
 
@@ -31,7 +31,7 @@ function* deleteFriendSaga({ payload }: ReturnType<typeof Action.deleteFriend>) 
     yield put(Action.deleteFriendSuccess(data.uuid))
     alert.deleteFriend()
   } catch (e) {
-    alert.error(e.response.data.data.message)
+    alert.error(e.message)
   }
 }
 export default function* friendsSaga() {

--- a/packages/client/src/modules/sagas/friendsSaga.ts
+++ b/packages/client/src/modules/sagas/friendsSaga.ts
@@ -5,36 +5,30 @@ import {
 import * as Action from 'modules/friends/action'
 import * as request from 'common/request'
 import { alert } from 'common/utils'
-import { AxiosResponse } from 'axios'
-import { ApiUser } from 'types'
+import { unwrapPromise } from 'types'
 
-type ApiUsersType = AxiosResponse<request.ResponseType<ApiUser[]>>
 function* getFriendsSaga() {
   try {
-    const response: ApiUsersType = yield call(request.getFriendList)
-    yield put(Action.getFriendsSuccess(response.data.data))
+    const data: unwrapPromise<typeof request.getFriendList> = yield call(request.getFriendList)
+    yield put(Action.getFriendsSuccess(data))
   } catch (e) {
     alert.error(e.response.data.data.message)
   }
 }
-type ApiUserType = AxiosResponse<request.ResponseType<ApiUser>>
 function* addFriendSaga({ payload }: ReturnType<typeof Action.addFriend>) {
   try {
-    const response: ApiUserType = yield call(request.addFriend, payload)
-    yield put(Action.addFriendSuccess(response.data.data))
-    alert.addFriend(response.data.data.name)
+    const data: unwrapPromise<typeof request.addFriend> = yield call(request.addFriend, payload)
+    yield put(Action.addFriendSuccess(data))
+    alert.addFriend(data.name)
   } catch (e) {
     alert.error(e.response.data.data.message)
   }
 }
-interface UuidType {
-  uuid: string
-}
-type ApiUuidType = AxiosResponse<request.ResponseType<UuidType>>
+
 function* deleteFriendSaga({ payload }: ReturnType<typeof Action.deleteFriend>) {
   try {
-    const response: ApiUuidType = yield call(request.deleteFriend, payload)
-    yield put(Action.deleteFriendSuccess(response.data.data.uuid))
+    const data: unwrapPromise<typeof request.deleteFriend> = yield call(request.deleteFriend, payload)
+    yield put(Action.deleteFriendSuccess(data.uuid))
     alert.deleteFriend()
   } catch (e) {
     alert.error(e.response.data.data.message)

--- a/packages/client/src/modules/sagas/loginSaga.ts
+++ b/packages/client/src/modules/sagas/loginSaga.ts
@@ -27,7 +27,7 @@ function* loginRequestSaga({ payload }: ReturnType<typeof loginRequest>) {
     yield all([put(loginSuccess()), put(getProfile()), put(getFriends()), put(getRoomRequest())])
   } catch (e) {
     yield put(loginFailure(e))
-    alert.error(e.response.data.data.message)
+    alert.error(e.message)
   }
 }
 
@@ -36,7 +36,7 @@ function* logoutRequestSaga() {
     yield call(request.getLogout)
     yield all([put(logoutSuccess()), put(resetProfile()), put(resetFriends()), put(resetRoom())])
   } catch (e) {
-    alert.error(e.response.data.data.message)
+    alert.error(e.message)
   }
 }
 export default function* loginSaga() {

--- a/packages/client/src/modules/sagas/profileSaga.ts
+++ b/packages/client/src/modules/sagas/profileSaga.ts
@@ -11,7 +11,7 @@ function* getProfileSaga() {
     const data: unwrapPromise<typeof request.getProfile> = yield call(request.getProfile)
     yield put(Action.getProfileSuccess(data))
   } catch (e) {
-    alert.error(e.response.data.data.message)
+    alert.error(e.message)
   }
 }
 
@@ -20,7 +20,7 @@ function* updateProfileSaga({ payload }: ReturnType<typeof Action.updateProfileR
     const data: unwrapPromise<typeof request.updateProfile> = yield call(request.updateProfile, payload)
     yield put(Action.updateProfielSuccess(data))
   } catch (e) {
-    alert.error(e.response.data.data.message)
+    alert.error(e.message)
   }
 }
 export default function* profileSaga() {

--- a/packages/client/src/modules/sagas/profileSaga.ts
+++ b/packages/client/src/modules/sagas/profileSaga.ts
@@ -4,11 +4,12 @@ import {
 import * as Action from 'modules/profile/action'
 import * as request from 'common/request'
 import { alert } from 'common/utils'
+import { unwrapPromise } from 'types'
 
 function* getProfileSaga() {
   try {
-    const response = yield call(request.getProfile)
-    yield put(Action.getProfileSuccess(response.data.data))
+    const data: unwrapPromise<typeof request.getProfile> = yield call(request.getProfile)
+    yield put(Action.getProfileSuccess(data))
   } catch (e) {
     alert.error(e.response.data.data.message)
   }
@@ -16,8 +17,8 @@ function* getProfileSaga() {
 
 function* updateProfileSaga({ payload }: ReturnType<typeof Action.updateProfileRequest>) {
   try {
-    const response = yield call(request.updateProfile, payload)
-    yield put(Action.updateProfielSuccess(response.data.data))
+    const data: unwrapPromise<typeof request.updateProfile> = yield call(request.updateProfile, payload)
+    yield put(Action.updateProfielSuccess(data))
   } catch (e) {
     alert.error(e.response.data.data.message)
   }

--- a/packages/client/src/modules/sagas/roomSaga.ts
+++ b/packages/client/src/modules/sagas/roomSaga.ts
@@ -39,11 +39,11 @@ interface RoomReturnType{
 type roomIdType = AxiosResponse<request.ResponseType<RoomReturnType>>
 function* makeRoomSaga({ payload }: ReturnType<typeof makeRoomRequest>) {
   try {
-    const response: roomIdType = yield call(request.makeRoomRequest, payload)
-    const roomUuids = response.data.data.rooms.map((v) => v.uuid)
-    yield put(joinRooms({ roomUuids }))
-    yield put(getRoomSuccess(response.data.data.rooms))
-    yield call(push, `${url.room}/${response.data.data.roomUuid}`)
+    const response = yield call(request.makeRoomRequest, payload)
+    const roomUuids = response.rooms.map((v: any) => v.uuid)
+    joinRooms({ roomUuids })
+    yield put(getRoomSuccess(response.rooms))
+    yield call(push, `${url.room}/${response.roomUuid}`)
   } catch (e) {
     yield put(getRoomFailure(e.message))
   }

--- a/packages/client/src/modules/sagas/roomSaga.ts
+++ b/packages/client/src/modules/sagas/roomSaga.ts
@@ -1,5 +1,5 @@
 import {
-  call, put, takeEvery, takeLatest,
+  call, put, takeEvery,
 } from 'redux-saga/effects'
 
 import {
@@ -18,14 +18,15 @@ import {
 
 import { AxiosResponse } from 'axios'
 import { joinRooms } from 'modules/socket'
+import { unwrapPromise } from 'types'
 import { push } from '../../common/utils'
 
 function* room() {
   try {
-    const response: AxiosResponse<request.ResponseType<Models.Room[]>> = yield call(request.getRooms)
-    const roomUuids = response.data.data.map((v) => v.uuid)
+    const data: unwrapPromise<typeof request.getRooms> = yield call(request.getRooms)
+    const roomUuids = data.map((v) => v.uuid)
     yield put(joinRooms({ roomUuids }))
-    yield put(getRoomSuccess(response.data.data))
+    yield put(getRoomSuccess(data))
   } catch (e) {
     yield put(getRoomFailure(e.message))
   }

--- a/packages/client/src/pages/chatroom/ChatArea/ChatArea.tsx
+++ b/packages/client/src/pages/chatroom/ChatArea/ChatArea.tsx
@@ -35,8 +35,8 @@ const ChatArea: React.FC<Props> = ({
     if (!roomUuid) return
     const fetch = async () => {
       try {
-        const response = await request.getFirstChat({ roomUuid })
-        setFirstChat(response.data.data)
+        const data = await request.getFirstChat({ roomUuid })
+        setFirstChat(data)
       } catch (e) {
         setFirstChat(null)
       }

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -46,3 +46,9 @@ export interface InviteUser extends InviteUserType{
   uuid: string;
   name: string;
 }
+
+export type unwrapPromise<T> =
+T extends Promise<infer U> ? U :
+T extends (...args: any) => Promise<infer U> ? U :
+T extends (...args: any) => infer U ? U :
+T

--- a/packages/server/src/controllers/chat.ts
+++ b/packages/server/src/controllers/chat.ts
@@ -39,19 +39,16 @@ export const getChats = controllerHelper(async (req, res, next) => {
 
 export const getRoom = controllerHelper(async (req, res, next) => {
   const { roomId } = req.params
-  let rooms
   if (roomId) {
-    rooms = await chatService.findRoomByUuid(roomId)
-  } else {
-    const { googleId } = req.decodedUser!
-
-    const user = await userService.findByGoogleId(googleId)
-    if (!user) {
-      throw httpError.USER_NOT_FOUND
-    }
-    rooms = await chatService.findAllRooms(user.id)
+    return chatService.findRoomByUuid(roomId)
   }
-  return rooms
+  const { googleId } = req.decodedUser!
+
+  const user = await userService.findByGoogleId(googleId)
+  if (!user) {
+    throw httpError.USER_NOT_FOUND
+  }
+  return chatService.findAllRooms(user.id)
 })
 
 export const addMessage = controllerHelper(async (req, res, next) => {


### PR DESCRIPTION
request 함수 타입 수정
- 이런식으로 `request.somfunction()` 했을때 데이터가 바로 리턴됩니다.
- 리퀘스트마다 해줬던 `response.data.data` 같은 코드는 안써도 됩니다.
- 에러가 난 경우 바로 에러 메시지를 리턴해줍니다.
```typescript
async function Axios<T>(config: AxiosRequestConfig) {
  try {
    const response = await instance.request<ResponseType<T>>(config)
    return response.data.data
  } catch (e) {
    throw new Error(e.response.data.data.message)
  }
}
```