### PR TITLE
🔨  [리팩토링] response type 통일 [WIP]

### DIFF
--- a/packages/client/src/common/request.ts
+++ b/packages/client/src/common/request.ts
@@ -19,14 +19,8 @@ const instance = axios.create({
 export type ResponseType<T> = {
   success: boolean
   data: T
+  message?: string
 }
-
-export type AxiosResponseType<T> = AxiosResponse<ResponseType<T>>
-
-export type ApiCallback<T = {}> = (
-  err: AxiosResponse<ResponseType<T>> | null,
-  response?: AxiosResponse<ResponseType<T>>,
-) => void
 
 async function Axios<T>(config: AxiosRequestConfig) {
   try {

--- a/packages/client/src/common/request.ts
+++ b/packages/client/src/common/request.ts
@@ -1,11 +1,8 @@
-import axios, {
-  AxiosError, AxiosRequestConfig, AxiosResponse,
-} from 'axios'
+import axios, { AxiosRequestConfig } from 'axios'
 import * as Type from 'types'
 import {
   APIs, Models,
 } from '@kakio/common'
-import { Store } from 'modules'
 import { configs } from './constants'
 
 const API_SERVER_URL = configs.NODE_ENV_VAR === 'production' ? configs.API_SERVER_URL_PRODUCT : configs.API_SERVER_URL
@@ -31,7 +28,6 @@ async function Axios<T>(config: AxiosRequestConfig) {
     }
     throw new Error(response.data.message)
   } catch (e) {
-    // Store.store.dispatch(logoutRequest())
     throw new Error(e.message)
   }
 }

--- a/packages/client/src/common/request.ts
+++ b/packages/client/src/common/request.ts
@@ -2,7 +2,9 @@ import axios, {
   AxiosError, AxiosRequestConfig, AxiosResponse,
 } from 'axios'
 import * as Type from 'types'
-import { APIs, Models } from '@kakio/common'
+import {
+  APIs, Models,
+} from '@kakio/common'
 import { configs } from './constants'
 
 const API_SERVER_URL = configs.NODE_ENV_VAR === 'production' ? configs.API_SERVER_URL_PRODUCT : configs.API_SERVER_URL
@@ -35,23 +37,35 @@ async function Axios<T>(config: AxiosRequestConfig) {
   }
 }
 
-export const getProfile = () => Axios<Type.ApiUser>({ method: 'GET',
-  url: 'user/my-profile' })
+export const getProfile = () => Axios<Type.ApiUser>({
+  method: 'GET',
+  url: 'user/my-profile',
+})
 
-export const getFriendList = () => Axios<Type.ApiUser[]>({ method: 'GET',
-  url: 'social/friend-list' })
-export const getChatList = () => Axios({ method: 'GET',
-  url: 'dummy/chat-list' })
-export const getLogout = () => Axios({ method: 'GET',
-  url: 'auth/logout' })
-export const getUserInfo = () => Axios<Type.SimpleUserType>({ method: 'GET',
-  url: 'auth/check-auth' })
+export const getFriendList = () => Axios<Type.ApiUser[]>({
+  method: 'GET',
+  url: 'social/friend-list',
+})
+export const getChatList = () => Axios({
+  method: 'GET',
+  url: 'dummy/chat-list',
+})
+export const getLogout = () => Axios({
+  method: 'GET',
+  url: 'auth/logout',
+})
+export const getUserInfo = () => Axios<Type.SimpleUserType>({
+  method: 'GET',
+  url: 'auth/check-auth',
+})
 
 interface GetFirstChat extends AxiosRequestConfig{
   roomUuid: string
 }
-export const getFirstChat = ({ roomUuid }: GetFirstChat) => Axios<APIs.GetFirstChat>({ method: 'GET',
-  url: `chat/first-chat/${roomUuid}` })
+export const getFirstChat = ({ roomUuid }: GetFirstChat) => Axios<APIs.GetFirstChat>({
+  method: 'GET',
+  url: `chat/first-chat/${roomUuid}`,
+})
 
 interface GetLoginArgs {
   googleId: string
@@ -66,8 +80,10 @@ export const getLogin = (args: GetLoginArgs) => Axios({
   data: args,
 })
 
-export const getRooms = () => Axios<Models.Room[]>({ method: 'GET',
-  url: 'chat/room' })
+export const getRooms = () => Axios<Models.Room[]>({
+  method: 'GET',
+  url: 'chat/room',
+})
 
 export const addFriend = (email: string) => Axios<Type.ApiUser>({
   method: 'POST',
@@ -80,14 +96,18 @@ export const deleteFriend = (uuid: string) => Axios<{uuid: string}>({
   url: 'social/delete-friend',
   data: { uuid },
 })
-export const updateProfile = ({ name,
-  statusMessage }: {
+export const updateProfile = ({
+  name,
+  statusMessage,
+}: {
   name: string
   statusMessage: string
 }) => Axios<Type.ApiUser>({
   method: 'PATCH',
   url: 'user/update-profile',
-  data: { name, statusMessage },
+  data: {
+    name, statusMessage,
+  },
 })
 
 interface GetChatByRoom {
@@ -106,8 +126,10 @@ export const getChatByRoom = ({
   roomUuid,
   limit,
   offset,
-}: GetChatByRoom) => Axios<Chat>({ method: 'GET',
-  url: `/chat/message/${roomUuid}?offset=${offset}&limit=${limit}` })
+}: GetChatByRoom) => Axios<Chat>({
+  method: 'GET',
+  url: `/chat/message/${roomUuid}?offset=${offset}&limit=${limit}`,
+})
 
 export const loadMoreChat = ({
   roomUuid,
@@ -121,8 +143,10 @@ export const loadMoreChat = ({
   chats: Type.ApiChat[]
   offset: number
   limit: number}
->({ method: 'GET',
-  url: `/chat/message/${roomUuid}?offset=${offset}&limit=${limit}` })
+>({
+  method: 'GET',
+  url: `/chat/message/${roomUuid}?offset=${offset}&limit=${limit}`,
+})
 
 export const makeRoomRequest = (args: Type.InviteUser[]) => Axios<Pick<Models.Room, 'uuid'>>({
   method: 'POST',

--- a/packages/client/src/common/request.ts
+++ b/packages/client/src/common/request.ts
@@ -5,6 +5,7 @@ import * as Type from 'types'
 import {
   APIs, Models,
 } from '@kakio/common'
+import { Store } from 'modules'
 import { configs } from './constants'
 
 const API_SERVER_URL = configs.NODE_ENV_VAR === 'production' ? configs.API_SERVER_URL_PRODUCT : configs.API_SERVER_URL
@@ -25,9 +26,13 @@ export type ResponseType<T> = {
 async function Axios<T>(config: AxiosRequestConfig) {
   try {
     const response = await instance.request<ResponseType<T>>(config)
-    return response.data.data
+    if (response.data.success) {
+      return response.data.data
+    }
+    throw new Error(response.data.message)
   } catch (e) {
-    throw new Error(e.response.data.data.message)
+    // Store.store.dispatch(logoutRequest())
+    throw new Error(e.message)
   }
 }
 

--- a/packages/client/src/common/utils.ts
+++ b/packages/client/src/common/utils.ts
@@ -1,6 +1,5 @@
 import moment from 'moment'
 import swal from 'sweetalert'
-import { useEffect } from 'react'
 import 'moment/locale/ko'
 import { createBrowserHistory } from 'history'
 

--- a/packages/client/src/common/utils.ts
+++ b/packages/client/src/common/utils.ts
@@ -25,13 +25,12 @@ export const getCurTimeDBFormat = () => moment(Date.now()).format(DB_TIME_FORMAT
 
 export const getCurTimeDBFormatForTest = (date: Date) => Date.now()
 
-const alert = {
+export const alert = {
   addFriend: (name: string) => swal(`${name}님을 친구로 추가했습니다.`, '', 'success'),
   deleteFriend: () => swal('삭제되었습니다.', '', 'success'),
   confirmDelete: (name: string) => swal(`${name}님을 친구에서 삭제하시겠습니까?`, { buttons: ['취소', true] }),
   error: (message: string) => swal(message, '', 'error'),
 }
-export { alert }
 
 export const push = (targetUrl: string) => {
   browserHistory.push(targetUrl)

--- a/packages/client/src/components/Drawer/Drawer.tsx
+++ b/packages/client/src/components/Drawer/Drawer.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { usePrevious } from 'hooks'
 import * as S from './styles'
 
 interface Props{
@@ -17,7 +16,6 @@ const Drawer: React.FC<Props> = ({
   const [isOpen, setIsOpen] = useState(false)
   const [sectionOpen, setSectionOpen] = useState(false)
   const [bgOpen, setBgOpen] = useState(false)
-  const ref = useRef(false)
   const bgRef = useRef(false)
   const sectionRef = useRef(false)
 

--- a/packages/client/src/components/GoogleSignin/index.tsx
+++ b/packages/client/src/components/GoogleSignin/index.tsx
@@ -12,9 +12,9 @@ import {
 import {
   configs, url,
 } from 'common/constants'
-import { alert } from 'common/utils'
 import { loginRequest } from 'modules/login'
 import { RootState } from 'modules'
+import * as AlertAction from 'modules/alert'
 
 const loginURL = configs.NODE_ENV_VAR === 'production' ? configs.LOGIN_URL_PRODUCT : configs.LOGIN_URL
 
@@ -38,7 +38,7 @@ const GoogleSignin: React.FC = () => {
     }))
   }
   const responseFail = (err: Error) => {
-    alert.error(err.message)
+    dispatch(AlertAction.error(err.message))
   }
   const responseAutoLoad = (success: boolean) => {
     console.warn(success)

--- a/packages/client/src/components/NavigationBar/MakeChatTab/index.tsx
+++ b/packages/client/src/components/NavigationBar/MakeChatTab/index.tsx
@@ -1,5 +1,5 @@
 import React, {
-  FC, useEffect, useState,
+  FC, useState,
 } from 'react'
 import styled from 'styled-components'
 import { color } from 'styles/global'
@@ -30,7 +30,6 @@ interface MakeChatProp{
 const MakeChatTab: FC<MakeChatProp> = ({ size = '1.5rem' }) => {
   const [isClicked, setClicked] = useState(false)
   const [selectedList, setSelectedList] = useState<InviteUser[]>([])
-  const room = useSelector((state: RootState) => state.room)
   const myProfile = useSelector((state: RootState) => state.profile)
   const handlePopUpClick = () => {
     setClicked(!isClicked)

--- a/packages/client/src/hooks/useAuth.ts
+++ b/packages/client/src/hooks/useAuth.ts
@@ -1,9 +1,5 @@
-import {
-  useEffect, useState,
-} from 'react'
-import * as request from 'common/request'
+import { useEffect } from 'react'
 import { url } from 'common/constants'
-
 import { useHistory } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import { RootState } from 'modules'

--- a/packages/client/src/modules/alert/action.ts
+++ b/packages/client/src/modules/alert/action.ts
@@ -2,6 +2,7 @@ export const LOGIN_FAILURE = 'alert/LOGIN_FAILURE' as const
 export const ADD_FRIEND = 'alert/ADD_FRIENND' as const
 export const DELETE_FRIEND = 'alert/DELETE_FRIEND' as const
 export const Error = 'alert/Error' as const
+export const CONFIRM_DELETE = 'alert/CONFIRM_DELETE' as const
 
 export const loginFailure = (msg: string) => ({
   type: LOGIN_FAILURE,
@@ -18,4 +19,11 @@ export const deleteFriend = () => ({ type: DELETE_FRIEND })
 export const error = (msg: string) => ({
   type: Error,
   payload: { msg },
+})
+
+export const confirmDelete = (name: string, cb: Function) => ({
+  type: CONFIRM_DELETE,
+  payload: {
+    name, cb,
+  },
 })

--- a/packages/client/src/modules/alert/action.ts
+++ b/packages/client/src/modules/alert/action.ts
@@ -1,0 +1,21 @@
+export const LOGIN_FAILURE = 'alert/LOGIN_FAILURE' as const
+export const ADD_FRIEND = 'alert/ADD_FRIENND' as const
+export const DELETE_FRIEND = 'alert/DELETE_FRIEND' as const
+export const Error = 'alert/Error' as const
+
+export const loginFailure = (msg: string) => ({
+  type: LOGIN_FAILURE,
+  payload: { msg },
+})
+
+export const addFriend = (msg: string) => ({
+  type: ADD_FRIEND,
+  payload: { msg },
+})
+
+export const deleteFriend = () => ({ type: DELETE_FRIEND })
+
+export const error = (msg: string) => ({
+  type: Error,
+  payload: { msg },
+})

--- a/packages/client/src/modules/alert/index.ts
+++ b/packages/client/src/modules/alert/index.ts
@@ -1,0 +1,3 @@
+export { default } from 'modules/alert/reducer'
+export * from 'modules/alert/action'
+export * from 'modules/alert/types'

--- a/packages/client/src/modules/alert/reducer.ts
+++ b/packages/client/src/modules/alert/reducer.ts
@@ -20,6 +20,17 @@ const reducer = (state = {}, action: AlertType) => {
       alert.error(action.payload.msg)
       return state
     }
+    case Action.CONFIRM_DELETE: {
+      const {
+        name, cb,
+      } = action.payload
+      alert.confirmDelete(name).then((confirm) => {
+        if (confirm) {
+          cb()
+        }
+      })
+      return state
+    }
     default: {
       return state
     }

--- a/packages/client/src/modules/alert/reducer.ts
+++ b/packages/client/src/modules/alert/reducer.ts
@@ -1,0 +1,29 @@
+import * as Action from 'modules/alert/action'
+import { AlertType } from 'modules/alert/types'
+import { alert } from 'common/utils'
+
+const reducer = (state = {}, action: AlertType) => {
+  switch (action.type) {
+    case Action.LOGIN_FAILURE: {
+      alert.error(action.payload.msg)
+      return state
+    }
+    case Action.ADD_FRIEND: {
+      alert.addFriend(action.payload.msg)
+      return state
+    }
+    case Action.DELETE_FRIEND: {
+      alert.deleteFriend()
+      return state
+    }
+    case Action.Error: {
+      alert.error(action.payload.msg)
+      return state
+    }
+    default: {
+      return state
+    }
+  }
+}
+
+export default reducer

--- a/packages/client/src/modules/alert/types.ts
+++ b/packages/client/src/modules/alert/types.ts
@@ -5,3 +5,4 @@ export type AlertType =
 | ReturnType<typeof Action.addFriend>
 | ReturnType<typeof Action.deleteFriend>
 | ReturnType<typeof Action.error>
+| ReturnType<typeof Action.confirmDelete>

--- a/packages/client/src/modules/alert/types.ts
+++ b/packages/client/src/modules/alert/types.ts
@@ -1,0 +1,7 @@
+import * as Action from 'modules/alert/action'
+
+export type AlertType =
+| ReturnType<typeof Action.loginFailure>
+| ReturnType<typeof Action.addFriend>
+| ReturnType<typeof Action.deleteFriend>
+| ReturnType<typeof Action.error>

--- a/packages/client/src/modules/login/reducer.ts
+++ b/packages/client/src/modules/login/reducer.ts
@@ -1,7 +1,6 @@
 import * as Action from 'modules/login/action'
 import { LoginInfo } from 'types'
 import { LoginAction } from 'modules/login/types'
-import { alert } from 'common/utils'
 
 const initialState: LoginInfo = { isLoggedIn: false }
 
@@ -11,12 +10,7 @@ function login(state: LoginInfo = initialState, action: LoginAction) {
       return { isLoggedIn: true }
     }
     case Action.LOGIN_FAILURE: {
-      const error = action.payload
-      if (error) {
-        console.error(error)
-        alert.error(error)
-      }
-      return state
+      return initialState
     }
     case Action.LOGOUT_REQUEST: {
       return { isLoggedIn: false }

--- a/packages/client/src/modules/profile/action.ts
+++ b/packages/client/src/modules/profile/action.ts
@@ -1,4 +1,3 @@
-import { Models } from '@kakio/common'
 import { ApiUser } from 'types'
 
 export const GET_PROFILE_REQUEST = 'profile/GET_PROFILE' as const

--- a/packages/client/src/modules/room/reducer.ts
+++ b/packages/client/src/modules/room/reducer.ts
@@ -35,9 +35,7 @@ const room = (state: RoomState = initialState, action: RoomAction) => {
       }
     }
     case Action.LEAVE_ROOM_SUCCESS: {
-      const {
-        roomUuid, userUuid,
-      } = action.payload
+      const { roomUuid } = action.payload
       return {
         ...state,
         data: state.data.filter((v) => v.uuid !== roomUuid),

--- a/packages/client/src/modules/rootReducer.ts
+++ b/packages/client/src/modules/rootReducer.ts
@@ -6,6 +6,7 @@ import profile from 'modules/profile'
 import login from 'modules/login'
 import room from 'modules/room'
 import chat from 'modules/chat'
+import alert from 'modules/alert'
 
 const persistConfig = {
   key: 'root',
@@ -19,6 +20,7 @@ const rootReducer = combineReducers({
   login,
   room,
   chat,
+  alert,
 })
 
 export default persistReducer(persistConfig, rootReducer)

--- a/packages/client/src/modules/sagas/chatSaga.ts
+++ b/packages/client/src/modules/sagas/chatSaga.ts
@@ -15,9 +15,7 @@ import {
 
 import { unwrapPromise } from 'types'
 import * as request from 'common/request'
-import {
-  RootState, Store,
-} from 'modules'
+import { Store } from 'modules'
 
 function* getChatSaga(action: ReturnType<typeof getChatRequest>) {
   try {

--- a/packages/client/src/modules/sagas/friendsSaga.ts
+++ b/packages/client/src/modules/sagas/friendsSaga.ts
@@ -4,24 +4,24 @@ import {
 
 import * as Action from 'modules/friends/action'
 import * as request from 'common/request'
-import { alert } from 'common/utils'
 import { unwrapPromise } from 'types'
+import * as AlertAction from 'modules/alert/action'
 
 function* getFriendsSaga() {
   try {
     const data: unwrapPromise<typeof request.getFriendList> = yield call(request.getFriendList)
     yield put(Action.getFriendsSuccess(data))
   } catch (e) {
-    alert.error(e.message)
+    yield put(AlertAction.error(e.message))
   }
 }
 function* addFriendSaga({ payload }: ReturnType<typeof Action.addFriend>) {
   try {
     const data: unwrapPromise<typeof request.addFriend> = yield call(request.addFriend, payload)
     yield put(Action.addFriendSuccess(data))
-    alert.addFriend(data.name)
+    yield put(AlertAction.addFriend(data.name))
   } catch (e) {
-    alert.error(e.message)
+    yield put(AlertAction.error(e.message))
   }
 }
 
@@ -29,9 +29,9 @@ function* deleteFriendSaga({ payload }: ReturnType<typeof Action.deleteFriend>) 
   try {
     const data: unwrapPromise<typeof request.deleteFriend> = yield call(request.deleteFriend, payload)
     yield put(Action.deleteFriendSuccess(data.uuid))
-    alert.deleteFriend()
+    yield put(AlertAction.deleteFriend())
   } catch (e) {
-    alert.error(e.message)
+    yield put(AlertAction.error(e.message))
   }
 }
 export default function* friendsSaga() {

--- a/packages/client/src/modules/sagas/loginSaga.ts
+++ b/packages/client/src/modules/sagas/loginSaga.ts
@@ -18,8 +18,8 @@ import {
 import {
   getRoomRequest, resetRoom,
 } from 'modules/room'
-import { alert } from 'common/utils'
 import * as request from 'common/request'
+import * as AlertAction from 'modules/alert'
 
 function* loginRequestSaga({ payload }: ReturnType<typeof loginRequest>) {
   try {
@@ -27,7 +27,7 @@ function* loginRequestSaga({ payload }: ReturnType<typeof loginRequest>) {
     yield all([put(loginSuccess()), put(getProfile()), put(getFriends()), put(getRoomRequest())])
   } catch (e) {
     yield put(loginFailure(e))
-    alert.error(e.message)
+    yield put(AlertAction.error(e.message))
   }
 }
 
@@ -36,7 +36,7 @@ function* logoutRequestSaga() {
     yield call(request.getLogout)
     yield all([put(logoutSuccess()), put(resetProfile()), put(resetFriends()), put(resetRoom())])
   } catch (e) {
-    alert.error(e.message)
+    yield put(AlertAction.error(e.message))
   }
 }
 export default function* loginSaga() {

--- a/packages/client/src/modules/sagas/profileSaga.ts
+++ b/packages/client/src/modules/sagas/profileSaga.ts
@@ -3,15 +3,15 @@ import {
 } from 'redux-saga/effects'
 import * as Action from 'modules/profile/action'
 import * as request from 'common/request'
-import { alert } from 'common/utils'
 import { unwrapPromise } from 'types'
+import * as AlertAction from 'modules/alert'
 
 function* getProfileSaga() {
   try {
     const data: unwrapPromise<typeof request.getProfile> = yield call(request.getProfile)
     yield put(Action.getProfileSuccess(data))
   } catch (e) {
-    alert.error(e.message)
+    yield put(AlertAction.error(e.message))
   }
 }
 
@@ -20,7 +20,7 @@ function* updateProfileSaga({ payload }: ReturnType<typeof Action.updateProfileR
     const data: unwrapPromise<typeof request.updateProfile> = yield call(request.updateProfile, payload)
     yield put(Action.updateProfielSuccess(data))
   } catch (e) {
-    alert.error(e.message)
+    yield put(AlertAction.error(e.message))
   }
 }
 export default function* profileSaga() {

--- a/packages/client/src/modules/sagas/roomSaga.ts
+++ b/packages/client/src/modules/sagas/roomSaga.ts
@@ -12,9 +12,7 @@ import {
 
 import * as request from 'common/request'
 import { url } from 'common/constants'
-import {
-  APIs, Models,
-} from '@kakio/common'
+import { Models } from '@kakio/common'
 
 import { AxiosResponse } from 'axios'
 import { joinRooms } from 'modules/socket'

--- a/packages/client/src/pages/chatroom/ChatArea/ChatArea.tsx
+++ b/packages/client/src/pages/chatroom/ChatArea/ChatArea.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { ApiChat } from 'types'
 import * as request from 'common/request'
 import { APIs } from '@kakio/common'
 import { useSelector } from 'react-redux'
@@ -24,12 +23,6 @@ const ChatArea: React.FC<Props> = ({
   const [firstChat, setFirstChat] = useState<APIs.GetFirstChat | null>(null)
   const chatContainerRef = useRef<HTMLDivElement>(null)
   const chatBottomRef = useRef<HTMLDivElement>(null)
-  const chatState = useSelector((state: RootState) => state.chat)
-
-  // useEffect(() => {
-  //   if (!chatContainerRef.current) return
-  //   console.log(chatContainerRef.current.scrollTop)
-  // }, [chatState])
 
   useEffect(() => {
     if (!roomUuid) return

--- a/packages/client/src/pages/chatroom/ChatArea/ChatList/ChatList.tsx
+++ b/packages/client/src/pages/chatroom/ChatArea/ChatList/ChatList.tsx
@@ -1,6 +1,4 @@
 import React from 'react'
-import styled from 'styled-components'
-import { ApiChat } from 'types'
 import { APIs } from '@kakio/common'
 import { Loader } from 'components'
 import ChatBox from 'components/ChatBox'
@@ -36,7 +34,6 @@ const ChatList: React.FC<Props> = ({
   firstChat,
   chatContainerRef,
 }) => {
-  const dateToday = useRef<string>('')
   const dispatch = useDispatch()
   const chatState = useSelector((state: RootState) => state.chat)
   const root = useRef<HTMLDivElement>(null)

--- a/packages/client/src/pages/chatroom/Header/Header.tsx
+++ b/packages/client/src/pages/chatroom/Header/Header.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Icon from 'Icon/Icon'
 import { useHistory } from 'react-router-dom'
-import * as request from 'common/request'
 import * as S from './styles'
 
 interface Props{

--- a/packages/client/src/pages/chatroom/index.tsx
+++ b/packages/client/src/pages/chatroom/index.tsx
@@ -11,11 +11,7 @@ import { useAuth } from 'hooks'
 import {
   useDispatch, useSelector,
 } from 'react-redux'
-import {
-  Dialog, Drawer,
-  Loader,
-} from 'components'
-import Icon from 'Icon/Icon'
+import { Loader } from 'components'
 import { RootState } from 'modules'
 import { joinRooms } from 'modules/socket'
 
@@ -36,10 +32,8 @@ const ChatRoom: FC = () => {
   const [roomName, setRoomName] = useState<string>('')
   const dispatch = useDispatch()
   const roomState = useSelector((state: RootState) => state.room)
-  const { isLoggedIn } = useAuth()
   const { uuid } = useSelector((state: RootState) => state.profile)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  const [isLeaveAlertOpen, setIsLeaveAlertOpen] = useState(false)
   const [thisRoomState, setThisRoomState] = useState<RoomData | undefined>(undefined)
 
   const toggleSearchBar = useCallback(() => {

--- a/packages/client/src/pages/main/Friend/index.tsx
+++ b/packages/client/src/pages/main/Friend/index.tsx
@@ -1,5 +1,5 @@
 import React, {
-  FC, Fragment, useEffect,
+  FC, Fragment,
 } from 'react'
 import { List } from 'system'
 import Hr from 'atoms/Hr'

--- a/packages/client/src/pages/main/index.tsx
+++ b/packages/client/src/pages/main/index.tsx
@@ -6,9 +6,7 @@ import {
   Loader, NavigationBar,
 } from 'components'
 import { Room } from 'system'
-import {
-  useDispatch, useSelector,
-} from 'react-redux'
+import { useSelector } from 'react-redux'
 import { Route } from 'react-router-dom'
 import { url } from 'common/constants'
 import { afterLogin } from 'modules/socket'

--- a/packages/client/src/system/Profile/index.tsx
+++ b/packages/client/src/system/Profile/index.tsx
@@ -11,7 +11,6 @@ import {
   useDispatch, useSelector,
 } from 'react-redux'
 import { updateProfileRequest } from 'modules/profile'
-import { alert } from 'common/utils'
 import { deleteFriend } from 'modules/friends'
 import { makeRoomRequest } from 'modules/room'
 import { throttle } from 'lodash'
@@ -63,7 +62,6 @@ const Profile: FC<Prop> = ({
 
   const myProfile = useSelector((state: RootState) => state.profile)
 
-  const login = useSelector((state: RootState) => state.login)
   const [selectedList, setSelectedList] = useState([{
     uuid, name,
   }])
@@ -88,16 +86,9 @@ const Profile: FC<Prop> = ({
   }
 
   const onDeleteClick = () => {
-    alert.confirmDelete(name).then((confirm) => {
-      if (confirm) {
-        dispatch(deleteFriend(uuid))
-      }
-    })
+    dispatch(AlertAction.confirmDelete(name, () => dispatch(deleteFriend(uuid))))
   }
   const onChatClick = () => {
-    const {
-      uuid: userUuid, name: userName,
-    } = myProfile
     dispatch(makeRoomRequest(selectedList.concat({
       uuid, name,
     })))

--- a/packages/client/src/system/Profile/index.tsx
+++ b/packages/client/src/system/Profile/index.tsx
@@ -17,6 +17,7 @@ import { makeRoomRequest } from 'modules/room'
 import { throttle } from 'lodash'
 import { RootState } from 'modules'
 import { useInput } from 'hooks'
+import * as AlertAction from 'modules/alert'
 
 interface Prop {
   /** 유져 식별자 */
@@ -70,7 +71,7 @@ const Profile: FC<Prop> = ({
   const handleEditClick = () => {
     if (isEditMode) {
       if (editName.value.length === 0) {
-        alert.error('이름을 입력해주세요!')
+        dispatch(AlertAction.error('이름을 입력해주세요!'))
         return
       }
 

--- a/packages/client/src/system/Room/index.tsx
+++ b/packages/client/src/system/Room/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-nested-ternary */
-import React, { Fragment } from 'react'
+import React from 'react'
 import List from 'system/List'
 import {
   RouteComponentProps, withRouter,

--- a/packages/server/src/common/error.ts
+++ b/packages/server/src/common/error.ts
@@ -72,3 +72,14 @@ export const CANNOT_ADD_ROOM_PARTICIPANT = _he(_code.BAD_REQUEST, '잘못된 요
  */
 export const CAN_NOT_BE_DONE = _he(_code.NOT_ACCEPTABLE, '요청을 완료하지 못했습니다.')
 
+export const INVALID_GOOGLE_ID = _he(_code.UNAUTHORIZED, '계정이 유효하지 않습니다.')
+
+export const CAN_NOT_ADD_ME = _he(_code.UNAUTHORIZED, '본인은 친구로 추가할 수 없습니다.')
+
+export const INVALID_EMAIL = _he(_code.UNAUTHORIZED, '유효하지 않은 이메일입니다.')
+
+export const ALREADY_EXIST_FRIEND = _he(_code.UNAUTHORIZED, '이미 추가되어 있는 친구입니다.')
+
+export const INVALID_FRIEND_ID = _he(_code.UNAUTHORIZED, '친구의 계정이 유효하지 않습니다.')
+
+export const ERROR_OCCURED = _he(_code.UNAUTHORIZED, '오류가 발생했습니다.')

--- a/packages/server/src/common/error.ts
+++ b/packages/server/src/common/error.ts
@@ -1,85 +1,93 @@
 import _he from 'http-errors'
 import _code from 'http-status'
 
+const ERROR_CODE = _code.INTERNAL_SERVER_ERROR
 /**
- * @code
- * NOT FOUND (404)
  * @message
  * 방 정보가 없습니다.
  */
-export const ROOM_NOT_FOUND = _he(_code.NOT_FOUND, '방 정보가 없습니다.')
+export const ROOM_NOT_FOUND = _he(ERROR_CODE, '방 정보가 없습니다.')
 
 /**
- * @code
- * NOT FOUND (404)
  * @message
  * 데이터를 찾을 수 없습니다.
  */
-export const DATA_NOT_FOUND = _he(_code.NOT_FOUND, '데이터를 찾을 수 없습니다.')
+export const DATA_NOT_FOUND = _he(ERROR_CODE, '데이터를 찾을 수 없습니다.')
 
 /**
- * @code
- * UNAUTHORIZED (401)
  * @message
  * 유저정보를 찾을 수 없습니다.
  */
-export const USER_NOT_FOUND = _he(_code.UNAUTHORIZED, '유저정보를 찾을 수 없습니다.')
+export const USER_NOT_FOUND = _he(ERROR_CODE, '유저정보를 찾을 수 없습니다.')
 
 /**
- * @code
- * UNAUTHORIZED (401)
  * @message
  * 로그인이 필요한 서비스입니다
  */
-export const UNAUTHORIZED = _he(_code.UNAUTHORIZED, '로그인이 필요한 서비스입니다.')
+export const UNAUTHORIZED = _he(ERROR_CODE, '로그인이 필요한 서비스입니다.')
 
 /**
- * @code
- * NOT FOUND (404)
  * @message
  * 무언가 잘못되었습니다.
  */
-export const IDK = _he(_code.NOT_FOUND, '무언가 잘못되었습니다.')
+export const IDK = _he(ERROR_CODE, '무언가 잘못되었습니다.')
 
 /**
- * @code
- * NOT FOUND (400)
  * @message
  * 잘못된 요청입니다.
  */
-export const BAD_REQUEST = _he(_code.BAD_REQUEST, '잘못된 요청입니다.')
+export const BAD_REQUEST = _he(ERROR_CODE, '잘못된 요청입니다.')
 
 /**
- * @code
- * NOT FOUND (404)
  * @message
  * 방이 만들어지지 않았습니다.
  */
-export const ROOM_NOT_MADE = _he(_code.NOT_FOUND, '방이 만들어지지 않았습니다.')
+export const ROOM_NOT_MADE = _he(ERROR_CODE, '방이 만들어지지 않았습니다.')
 
 /**
- * @code
- * NOT FOUND (400)
  * @message
  * 방에 유저를 추가 할 수 없습니다.
  */
-export const CANNOT_ADD_ROOM_PARTICIPANT = _he(_code.BAD_REQUEST, '잘못된 요청입니다.')
+export const CANNOT_ADD_ROOM_PARTICIPANT = _he(ERROR_CODE, '잘못된 요청입니다.')
 
 /**
- * NOT FOUND (406)
  * @message
  * 잘못된 요청입니다.
  */
-export const CAN_NOT_BE_DONE = _he(_code.NOT_ACCEPTABLE, '요청을 완료하지 못했습니다.')
+export const CAN_NOT_BE_DONE = _he(ERROR_CODE, '요청을 완료하지 못했습니다.')
 
-export const INVALID_GOOGLE_ID = _he(_code.UNAUTHORIZED, '계정이 유효하지 않습니다.')
+/**
+ * @message
+ * 계정이 유효하지 않습니다.
+ */
+export const INVALID_GOOGLE_ID = _he(ERROR_CODE, '계정이 유효하지 않습니다.')
 
-export const CAN_NOT_ADD_ME = _he(_code.UNAUTHORIZED, '본인은 친구로 추가할 수 없습니다.')
+/**
+ * @message
+ * 본인은 친구로 추가할 수 없습니다.
+ */
+export const CAN_NOT_ADD_ME = _he(ERROR_CODE, '본인은 친구로 추가할 수 없습니다.')
 
-export const INVALID_EMAIL = _he(_code.UNAUTHORIZED, '유효하지 않은 이메일입니다.')
+/**
+ * @message
+ * 유효하지 않은 이메일입니다.
+ */
+export const INVALID_EMAIL = _he(ERROR_CODE, '유효하지 않은 이메일입니다.')
 
-export const ALREADY_EXIST_FRIEND = _he(_code.UNAUTHORIZED, '이미 추가되어 있는 친구입니다.')
+/**
+ * @message
+ * 이미 추가되어 있는 친구입니다.
+ */
+export const ALREADY_EXIST_FRIEND = _he(ERROR_CODE, '이미 추가되어 있는 친구입니다.')
 
-export const INVALID_FRIEND_ID = _he(_code.UNAUTHORIZED, '친구의 계정이 유효하지 않습니다.')
+/**
+ * @message
+ * 친구의 계정이 유효하지 않습니다.
+ */
+export const INVALID_FRIEND_ID = _he(ERROR_CODE, '친구의 계정이 유효하지 않습니다.')
 
-export const ERROR_OCCURED = _he(_code.UNAUTHORIZED, '오류가 발생했습니다.')
+/**
+ * @message
+ * 오류가 발생했습니다.
+ */
+export const ERROR_OCCURED = _he(ERROR_CODE, '오류가 발생했습니다.')

--- a/packages/server/src/common/utils.ts
+++ b/packages/server/src/common/utils.ts
@@ -41,13 +41,3 @@ export const controllerHelper: ControllerHelper = (controller) => async (req, re
     next(e)
   }
 }
-
-export const message = {
-  INVALID_GOOGLE_ID: '계정이 유효하지 않습니다.',
-  INVALID_EMAIL: '유효하지 않은 이메일입니다.',
-  INVALID_FRIEND_ID: '친구의 계정이 유효하지 않습니다.',
-  LOGIN_REQUIRED: '로그인이 필요합니다.',
-  ERROR_OCCURED: '오류가 발생했습니다.',
-  ALREADY_EXIST_FRIEND: '이미 추가되어 있는 친구입니다.',
-  CAN_NOT_ADD_ME: '본인은 친구로 추가할 수 없습니다.',
-}

--- a/packages/server/src/common/utils.ts
+++ b/packages/server/src/common/utils.ts
@@ -4,23 +4,26 @@ import httpStatus from 'http-status'
 import uuid4 from 'uuid4'
 import { ControllerHelper } from '../types'
 
-export const response = (res:Response, data = {}, code = httpStatus.OK) => {
+export const response = (res:Response, data: any = {}, _code = httpStatus.OK) => {
   let result = {
     success: true,
     data: {},
+    message: '',
   }
+  let code = _code
 
-  if (code > 399) {
+  if (_code > 399) {
     result.success = false
-    // code = httpStatus.OK;
+    result.message = data.message
+    code = httpStatus.OK
   }
 
-  if (typeof data === 'object') {
+  if (_code < 400 && typeof data === 'object') {
     result = {
-      ...result, data,
+      ...result,
+      data,
     }
   }
-
   return res.status(code).json(result)
 }
 

--- a/packages/server/src/controllers/auth.ts
+++ b/packages/server/src/controllers/auth.ts
@@ -1,13 +1,13 @@
 import {
   NextFunction, Request, Response,
 } from 'express'
-import createError from 'http-errors'
 import * as userService from '../services/user'
 import {
   cookieConfig, cookieName,
 } from '../configs'
 import { response } from '../common/utils'
 import loginService from '../services/auth'
+import * as httpError from '../common/error'
 
 const login = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -41,14 +41,12 @@ const logout = async (req: Request, res: Response, next: NextFunction) => {
 const getUserInfo = async (req: Request, res: Response, next: NextFunction) => {
   try {
     if (!req.decodedUser) {
-      next(createError(401, '로그인이 필요합니다.'))
-      return
+      throw httpError.UNAUTHORIZED
     }
     const { googleId } = req.decodedUser
     const user = await userService.findByGoogleId(googleId)
     if (!user) {
-      next(createError(404, '유저정보를 찾을 수 없습니다.'))
-      return
+      throw httpError.USER_NOT_FOUND
     }
 
     response(res, user)

--- a/packages/server/src/controllers/user.ts
+++ b/packages/server/src/controllers/user.ts
@@ -1,11 +1,9 @@
 import {
   NextFunction, Request, Response,
 } from 'express'
-import createError from 'http-errors'
-import {
-  message, response,
-} from '../common/utils'
+import { response } from '../common/utils'
 import * as userService from '../services/user'
+import * as httpError from '../common/error'
 
 const getMyProfile = async (
   req: Request,
@@ -14,11 +12,13 @@ const getMyProfile = async (
 ) => {
   try {
     if (!req.decodedUser) {
-      next(createError(401, message.LOGIN_REQUIRED))
-      return
+      throw httpError.UNAUTHORIZED
     }
     const user = await userService.findByGoogleId(req.decodedUser.googleId)
-    if (!user) throw createError(401, message.INVALID_GOOGLE_ID)
+
+    if (!user) {
+      throw httpError.INVALID_GOOGLE_ID
+    }
     const {
       uuid, email, name, statusMessage, imageUrl,
     } = user
@@ -41,8 +41,7 @@ const updateProfile = async (
 ) => {
   try {
     if (!req.decodedUser) {
-      next(createError(401, message.LOGIN_REQUIRED))
-      return
+      throw httpError.UNAUTHORIZED
     }
     await userService.updateProfile(
       req.decodedUser.googleId,
@@ -52,7 +51,9 @@ const updateProfile = async (
     const updatedUser = await userService.findByGoogleId(
       req.decodedUser.googleId
     )
-    if (!updatedUser) throw createError(401, message.INVALID_GOOGLE_ID)
+    if (!updatedUser) {
+      throw httpError.INVALID_GOOGLE_ID
+    }
     const {
       name, uuid, email, statusMessage, imageUrl,
     } = updatedUser

--- a/packages/server/src/middlewares/auth.ts
+++ b/packages/server/src/middlewares/auth.ts
@@ -6,13 +6,13 @@ import { IDecodedUser } from '../types'
 import {
   cookieName, jwtConfig,
 } from '../configs'
-import { message } from '../common/utils'
+import * as httpError from '../common/error'
 
 const isAuthenticated = (req: Request, res: Response, next: NextFunction) => {
   try {
     const token = req.cookies[cookieName]
     if (!token) {
-      throw new Error(message.LOGIN_REQUIRED)
+      throw httpError.UNAUTHORIZED
     }
     const decoded = jwt.verify(token, jwtConfig.secret)
 


### PR DESCRIPTION
closes #165 
closes #50 
api response type 통일작업중입니다.

@bbumjun 님이 `server/common/utils.ts` 에 작성하셨던 `message` 객체는 `server/common/error.ts` 에 통합되었습니다.

지금 아래와 같은 상태인데 모두 `401` 상태코드로 되있는것은 상의후에 통일하도록 하겠습니다.
```typescript
export const CAN_NOT_BE_DONE = _he(_code.NOT_ACCEPTABLE, '요청을 완료하지 못했습니다.')

export const INVALID_GOOGLE_ID = _he(_code.UNAUTHORIZED, '계정이 유효하지 않습니다.')

export const CAN_NOT_ADD_ME = _he(_code.UNAUTHORIZED, '본인은 친구로 추가할 수 없습니다.')

export const INVALID_EMAIL = _he(_code.UNAUTHORIZED, '유효하지 않은 이메일입니다.')

export const ALREADY_EXIST_FRIEND = _he(_code.UNAUTHORIZED, '이미 추가되어 있는 친구입니다.')

export const INVALID_FRIEND_ID = _he(_code.UNAUTHORIZED, '친구의 계정이 유효하지 않습니다.')

export const ERROR_OCCURED = _he(_code.UNAUTHORIZED, '오류가 발생했습니다.')

```

---

8e019d9 커밋으로 `confirmDelete` 까지 `alert action` 으로 다 작업했습니다.

다음에는 `SweetAlert` 걷어내고 `alert` 컴포넌트 자체제작 하고싶네요. 디자인 통일성이 `alert` 부분에서 좀 안맞아서요 ㅎ..