### PR TITLE
채팅목록 Refactoring

### DIFF
--- a/packages/client/src/common/utils.ts
+++ b/packages/client/src/common/utils.ts
@@ -19,12 +19,12 @@ export const convertMillToMMDDYYYY = (date: number) => {
 }
 
 export const convertToLL = (date: string) => moment(date).format('LL')
-
+export const convertToLT = (date: string) => moment(date).format('LT')
 export const getCurTimeDBFormat = () => moment(Date.now()).format(DB_TIME_FORMAT)
 
 export const getCurTimeDBFormatForTest = (date: Date) => Date.now()
 
-export const getDayDiff = (date: string) => Math.abs(moment(date).diff(moment(Date.now()), 'days'))
+export const getDayDiff = (date: string) => moment(date).format('LL') === moment(Date.now()).format('LL')
 export const alert = {
   addFriend: (name: string) => swal(`${name}님을 친구로 추가했습니다.`, '', 'success'),
   deleteFriend: () => swal('삭제되었습니다.', '', 'success'),

--- a/packages/client/src/components/ChatBox/ChatBox.tsx
+++ b/packages/client/src/components/ChatBox/ChatBox.tsx
@@ -16,11 +16,12 @@ type Props = {
   chat: ApiChat
   isMine: boolean
   ref?: React.Ref<HTMLDivElement>;
+  isYourFriend: boolean;
 }
 
 // eslint-disable-next-line react/display-name
 const ChatBox: React.ForwardRefExoticComponent<Props> = forwardRef(({
-  chat, isMine,
+  chat, isMine, isYourFriend,
 }, ref) => {
   const [isProfileClicked, setIsProfileClicked] = useState(false)
   const [isOverflow, setIsOverflow] = useState(false)
@@ -47,12 +48,14 @@ const ChatBox: React.ForwardRefExoticComponent<Props> = forwardRef(({
               <Profile
                 uuid={chat.uuid}
                 name={chat.metaInfo.sender.name}
+                email={chat.metaInfo.sender.email}
                 statusMessage={chat.metaInfo.sender.statusMessage}
                 handleCloseClick={handlePopUpClick}
                 imageUrl='https://images.unsplash.com/photo-1591369376214-b9f91924f10d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=634&q=80'
                 profileRef={profileRef}
                 isMyProfile={isMine}
                 isOverflow={isOverflow}
+                isYourFriend={isYourFriend}
               />
             </>
           )

--- a/packages/client/src/components/RoomCard/index.tsx
+++ b/packages/client/src/components/RoomCard/index.tsx
@@ -10,7 +10,6 @@ interface Props {
   numOfParticipants: number;
   lastMessage?: string;
   lastModified?: string;
-  numOfNewMessages?: number;
   onClick?: () => void;
 }
 const RoomCard: FC<Props> = ({
@@ -18,7 +17,6 @@ const RoomCard: FC<Props> = ({
   numOfParticipants,
   lastMessage = 'this is last message',
   lastModified = getCurTimeDBFormat(),
-  numOfNewMessages = 99,
   onClick = undefined,
 }) => {
   const dayDiffFromNow = getDayDiff(lastModified)

--- a/packages/client/src/components/RoomCard/index.tsx
+++ b/packages/client/src/components/RoomCard/index.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import * as S from 'components/RoomCard/styles'
 import Icon from 'Icon/Icon'
 import {
-  convertMillToMMDDYYYY, convertTimeForMsgFormat, getCurTimeDBFormat, getDayDiff,
+  convertToLL, convertToLT, getCurTimeDBFormat, getDayDiff,
 } from 'common/utils'
 
 interface Props {
@@ -37,7 +37,7 @@ const RoomCard: FC<Props> = ({
       </S.InfoWrapper>
     </S.RoomInfoWrapper>
     <S.SubInfoWrapper>
-      <S.Time>{ dayDiffFromNow >= 1 ? convertMillToMMDDYYYY(Date.parse(lastModified)) : convertTimeForMsgFormat(lastModified)}</S.Time>
+      <S.Time>{ dayDiffFromNow ? convertToLT(lastModified) : convertToLL(lastModified)}</S.Time>
     </S.SubInfoWrapper>
   </S.Container>
   )

--- a/packages/client/src/modules/friends/action.ts
+++ b/packages/client/src/modules/friends/action.ts
@@ -3,7 +3,7 @@ import { ApiUser } from 'types'
 export const GET_FRIENDS_REQUEST = 'friends/GET_FRIENDS_REQUEST' as const
 export const GET_FRIENDS_SUCCESS = 'friends/GET_FRIENDS_SUCCESS' as const
 export const ADD_FRIEND_REQUEST = 'friends/ADD_FRIEND' as const
-export const ADD_FRIEND_SUCCESS = 'friends/ADD_FRIEND_SUCCESS'
+export const ADD_FRIEND_SUCCESS = 'friends/ADD_FRIEND_SUCCESS' as const
 export const DELETE_FRIEND_REQUEST = 'friends/DELETE_FRIEND' as const
 export const DELETE_FRIEND_SUCCESS = 'friends/DELETE_FRIEND_SUCCESS' as const
 

--- a/packages/client/src/modules/friends/types.ts
+++ b/packages/client/src/modules/friends/types.ts
@@ -8,4 +8,3 @@ export type UserListAction =
 | ReturnType<typeof Action.addFriendSuccess>
 | ReturnType<typeof Action.deleteFriendSuccess>
 | ReturnType<typeof Action.resetFriends>
-| any

--- a/packages/client/src/pages/chatroom/ChatArea/ChatList/ChatList.tsx
+++ b/packages/client/src/pages/chatroom/ChatArea/ChatList/ChatList.tsx
@@ -41,6 +41,7 @@ const ChatList: React.FC<Props> = ({
   const [scrollHeight, setScrollHeight] = useState(10000)
   const prevScrollHeight = usePrevious(scrollHeight)
   const prevChats = usePrevious(chatState.data[roomUuid])
+  const friendState = useSelector((state: RootState) => state.friends)
 
   const lastTop = useCallback((node: HTMLDivElement) => {
     restorePos.current = node
@@ -96,6 +97,7 @@ const ChatList: React.FC<Props> = ({
                   chat={chat}
                   isMine={userUuid === chat.metaInfo.sender.uuid}
                   ref={idx === chats.length - 1 && chat.uuid !== firstChat.uuid ? first : null}
+                  isYourFriend={friendState.some((friend) => chat.metaInfo.sender.uuid === friend.uuid)}
                 />
               </div>
             ))

--- a/packages/client/src/system/Profile/index.tsx
+++ b/packages/client/src/system/Profile/index.tsx
@@ -5,16 +5,16 @@ import * as S from 'system/Profile/styles'
 import Icon from 'Icon/Icon'
 import { color } from 'styles/global'
 import TextIcon from 'components/TextIcon'
-import { Link } from 'react-router-dom'
 import Hr from 'atoms/Hr'
 import {
   useDispatch, useSelector,
 } from 'react-redux'
 import { updateProfileRequest } from 'modules/profile'
-import { deleteFriend } from 'modules/friends'
+import {
+  addFriend, deleteFriend,
+} from 'modules/friends'
 import { makeRoomRequest } from 'modules/room'
 import { throttle } from 'lodash'
-import { getProfile } from 'common/request'
 import { RootState } from 'modules'
 import { useInput } from 'hooks'
 import * as AlertAction from 'modules/alert'
@@ -36,6 +36,10 @@ interface Prop {
   isMyProfile: boolean
   /** 프로필 창 oveflow 여부 */
   isOverflow: boolean
+  /** 친구 여부 */
+  isYourFriend?: boolean
+  /** 유저 이메일 */
+  email?: string
 }
 
 /**
@@ -50,6 +54,8 @@ const Profile: FC<Prop> = ({
   profileRef,
   isMyProfile,
   isOverflow,
+  isYourFriend = true,
+  email = null,
 }) => {
   interface InviteUser{
     uuid: string;
@@ -120,6 +126,12 @@ const Profile: FC<Prop> = ({
       setSlideMount(0)
     }
   }
+
+  const handleAddFriend = () => {
+    if (email) {
+      dispatch(addFriend(email))
+    }
+  }
   return (
     <S.Container
       ref={profileRef}
@@ -171,7 +183,7 @@ const Profile: FC<Prop> = ({
 
         <Hr />
         <S.Footer>
-          {isMyProfile ? (
+          {isMyProfile && (
             <S.ButtonWrapper >
             <TextIcon
               icon={isEditMode ? 'Check' : 'Edit'}
@@ -185,8 +197,8 @@ const Profile: FC<Prop> = ({
             />
             </S.ButtonWrapper>
 
-          ) : (
-            <Fragment>
+          ) }
+          {isYourFriend ? <Fragment>
                 <S.ButtonWrapper>
                 <TextIcon
                   icon='ChatFilled'
@@ -213,7 +225,22 @@ const Profile: FC<Prop> = ({
               />
               </S.ButtonWrapper>
             </Fragment>
-          )}
+            : (
+              <S.ButtonWrapper>
+                <TextIcon
+                icon='AddFriend'
+                color={color.WHITE}
+                text='친구 추가'
+                textColor={color.WHITE}
+                iconPosition='top'
+                onClick={handleAddFriend}
+                size='1.2rem'
+                textSize='0.8rem'
+                />
+              </S.ButtonWrapper>
+
+            )
+            }
         </S.Footer>
       </S.ProfileWrapper>
     </S.Container>

--- a/packages/client/src/system/Profile/index.tsx
+++ b/packages/client/src/system/Profile/index.tsx
@@ -198,7 +198,8 @@ const Profile: FC<Prop> = ({
             </S.ButtonWrapper>
 
           ) }
-          {isYourFriend ? <Fragment>
+          {!isMyProfile && <>
+          ({isYourFriend ? <Fragment>
                 <S.ButtonWrapper>
                 <TextIcon
                   icon='ChatFilled'
@@ -240,7 +241,7 @@ const Profile: FC<Prop> = ({
               </S.ButtonWrapper>
 
             )
-            }
+            })</>}
         </S.Footer>
       </S.ProfileWrapper>
     </S.Container>

--- a/packages/client/src/system/Room/index.tsx
+++ b/packages/client/src/system/Room/index.tsx
@@ -42,7 +42,7 @@ const Room: React.FC<RouteComponentProps> = ({ history }) => {
               (participant) => participant.name
                 .toLowerCase()
                 .indexOf(roomKeyword.value.toLowerCase()) >= 0,
-            ),)
+            ),).sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
             .map(({
               uuid, participants, updatedAt, lastMessage,
             }) => {

--- a/packages/server/src/services/room.ts
+++ b/packages/server/src/services/room.ts
@@ -30,3 +30,10 @@ export const deleteRoom = async ({ roomUuid }: {roomUuid:string}) => {
   const deletedNum = await models.Room.destroy({ where: { uuid: roomUuid } })
   if (!deletedNum) throw httpError.CAN_NOT_BE_DONE
 }
+interface GetNewChatInfo {
+  roomUuid:string
+  updatedAt:string
+}
+export const updateRoomInfo = ({
+  roomUuid, updatedAt,
+}:GetNewChatInfo) => models.Room.update({ createdAt: updatedAt }, { where: { uuid: roomUuid } })

--- a/packages/server/src/socket/index.ts
+++ b/packages/server/src/socket/index.ts
@@ -46,6 +46,9 @@ const chatFromClient = socketCallBack((socket) => {
     console.log(chalk.cyan('chat from client'))
     try {
       const updatedAt = createdAt
+      await roomService.updateRoomInfo({
+        roomUuid, updatedAt,
+      })
       const data = await addMessage({
         roomUuid,
         content,


### PR DESCRIPTION
- 채팅방의 마지막 메시지 전송시간을 업데이트하는 로직을 추가했습니다.

  `chatFromClient`가 실행될 때 `room`의 `updateAt`을 업데이트 하려고했는데, 
  `room`의 `updateAt`을 업데이트하는 쿼리문을 날리면 아무 반응이 없어, `createAt`을  업데이트 하는 쿼리를 날렸더니 `updateAt`도 함께 업데이트 되면서 해결되었습니다..

- 채팅방 마지막 메시지 전송시간의 계산 과정의 에러를 수정했습니다.
  자정을 기준으로 하루가 지났을 때 날짜가, 그렇지 않으면 시간이 렌더링 되도록 구현하는 과정에서 기준이 자정이 아닌 24시간으로 계산되는 오류를 해결했습니다.

- Room 컴포넌트에서 각 채팅목록이 최신순으로 정렬되도록 수정

- 아직 친구가 아닌 유저에 의해 만들어진 채팅방에서 프로필 클릭시 친구추가 버튼 추가

----

실패한 작업

- 친구 추가 팝업창에서 `esc` 키를 눌렀을 때 창이 닫히는 기능을 구현하고자했는데, 다른 key와 다르게 `esc`를 눌렀을 때 focus out 되는 이벤트가 발생해서 기본 이벤트 방지 등 시도해봤는데 아예 독립적인 이벤트인건지 focus 가 벗어나버리는 동작이 계속 발생합니다..

-----

구현해야 하는 기능/작업

- 채팅목록에서 안읽은 메시지 있는 방에 표시해주는 기능
- 페이지 성능 개선 작업(불필요한 렌더링)